### PR TITLE
New gen rules

### DIFF
--- a/KenKen.m
+++ b/KenKen.m
@@ -6,7 +6,14 @@ generation rules plans:
 - sort the numbers on new game and a separate button, prevent confusion
 - fix bug with division only and negative numbers
 --- common divisor of 2 or -2 should be fine for example
+- hopefully consolidate most of the checks as they are currently spread
+around several functions
 
+arraySelection
+blobClip
+gridClip
+opSelection
+numSelection
 
 ===================================== new features
 copy notes to all of blob
@@ -39,6 +46,8 @@ Double right-clicking counts as a left click
 
 negative numbers don't accurately limit or allow certain op rules
 - using abs() will likely handle division only checks
+
+very large or small sizes for the enter tool may cause errors
 
 ===================================== Programming changes
 changing tabs shouldn't necessarily close the enter tool

--- a/KenKen.m
+++ b/KenKen.m
@@ -657,12 +657,12 @@ function [] = KenKen()
 	% Size' text box. A blank entry will be replaced by 4.
 	function [] = blobClip(~,~)
 		b = round(str2num(blobSize.String));
-		if isempty(b)
+		if isempty(b) || isnan(b)
 			b = 4;
-		elseif b<2
+		elseif b < 2
 			b = 2;
 		end
-		if b~=2 && allowedOps(2) && all(~allowedOps([1 3 4]))
+		if b ~= 2 && allowedOps(2) && all(~allowedOps([1 3 4]))
 			allowedOps(1) = true;
 			addCheck.Value = true;
 		end
@@ -677,7 +677,7 @@ function [] = KenKen()
 	function [] = gridClip(~,~)
 		a = gridSize.UserData;
 		b = round(str2num(gridSize.String));
-		if isempty(b)
+		if isempty(b) || isnan(b)
 			b = 5;
 		elseif b<2
 			b = 2;

--- a/KenKen.m
+++ b/KenKen.m
@@ -8,12 +8,22 @@ generation rules plans:
 --- common divisor of 2 or -2 should be fine for example
 - hopefully consolidate most of the checks as they are currently spread
 around several functions
+- allowedOps is somewhat redundant with *Check.Value.
+--- it's main use is for checking multiple *Check.Value in a single
+condition
+--- if all the rules are consolidated, it becomes less necessary
 
 arraySelection
 blobClip
 gridClip
 opSelection
 numSelection
+
+illegal gen rules:
+- division or subtraction only on blob size > 2
+- division only requires numbers in the form sort(abs(theNums)) =
+c*min.^(0:(n-1)), where min is the smallest magnitude and c is arbitrary
+- each number must be unique
 
 ===================================== new features
 copy notes to all of blob
@@ -688,7 +698,7 @@ function [] = KenKen()
 		b = round(str2num(gridSize.String));
 		if isempty(b) || isnan(b)
 			b = 5;
-		elseif b<2
+		elseif b < 2
 			b = 2;
 		end
 		s = num2str(b);

--- a/KenKen.m
+++ b/KenKen.m
@@ -170,8 +170,8 @@ function [] = KenKen()
 			blobSize.Tooltip = 'Must be size 2 with selected operators';
 		end
 		
-		% check sort(abs(theNums)) = c*min.^(0:(n-1)) for / only
-		if divCheck.Value && ~addCheck.Value && ~multCheck.Value && ~subCheck.Value && blobSize.UserData == 2
+		% division only, numbers are factors of each other
+		if divCheck.Value && ~addCheck.Value && ~multCheck.Value && ~subCheck.Value% && blobSize.UserData == 2
 			nums = sort(abs(numPicker.UserData));
 			nums = nums(2:end)./nums(1:end-1);
 			if ~all(round(nums) == nums) % each number is a factor of the number with the next largest magnitude
@@ -179,7 +179,7 @@ function [] = KenKen()
 				% turn op panel nad the numbers red
 				divCheck.Parent.ForegroundColor = [1 0 0];
 				set(numBoxes,'ForegroundColor',[1 0 0]);
-				divCheck.Tooltip = sprintf('Division as the only operator requires each number to be a factor\nof the number with the next in order of ascending magnitude.\nSelect another operator or try 2^x');
+				divCheck.Tooltip = sprintf('Division as the only operator requires each number to be a factor\nof the nex number, in order of ascending magnitude.\nSelect another operator or try 2^x');
 			end			
 		end
 		

--- a/KenKen.m
+++ b/KenKen.m
@@ -1,4 +1,13 @@
 %{
+generation rules plans:
+- fewer automatic "fixes" as they are confusing
+- if a rule is broken/not allowed, disable the New Game button
+--- somewhere add a tooltip explaining the source of the problem
+- sort the numbers on new game and a separate button, prevent confusion
+- fix bug with division only and negative numbers
+--- common divisor of 2 or -2 should be fine for example
+
+
 ===================================== new features
 copy notes to all of blob
 -copies notes in current square to all others of the same blob


### PR DESCRIPTION
Generation settings no longer auto-correct themselves. It was originally written to be helpful, but I found it more confusing than anything. Now if there are issues, the 'New Game' button is disabled and the offending settings will turn red and have tooltips explaining the issue(s)